### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,42 @@
+# Dev Container
+
+This repository includes a VS Code dev container for local kaos-control development.
+
+On container creation, `.devcontainer/post-create.sh` installs the Go, Node, pnpm, Claude Code, Codex, and Delve tooling used by the project. It also runs `.devcontainer/bootstrap-kaos-control.sh`, which creates a minimal local kaos-control app config:
+
+```text
+~/.kaos-control/config.yaml
+~/.kaos-control/projects/kaos-control.yaml
+~/.kaos-control/data/
+```
+
+The project entry points at the checked-out workspace, so the debug server can list this repo in the project picker.
+
+## Useful Commands
+
+```sh
+# Recreate the local kaos-control config/project entry.
+.devcontainer/bootstrap-kaos-control.sh
+
+# Start the backend with the devcontainer config.
+go run ./cmd/kaos-control serve -config ~/.kaos-control/config.yaml
+```
+
+The dev container forwards:
+
+| Port | Purpose |
+|---|---|
+| `5173` | Vite dev server |
+| `8080` | kaos-control server |
+
+## Bootstrap Overrides
+
+`bootstrap-kaos-control.sh` supports these environment variables:
+
+| Variable | Default |
+|---|---|
+| `KAOS_CONTROL_HOME` | `$HOME/.kaos-control` |
+| `KAOS_CONTROL_PROJECTS_DIR` | `$KAOS_CONTROL_HOME/projects` |
+| `KAOS_CONTROL_DATA_DIR` | `$KAOS_CONTROL_HOME/data` |
+| `KAOS_CONTROL_PROJECT_NAME` | repository directory name |
+| `KAOS_CONTROL_PROJECT_OWNER` | `git config user.email`, then `vscode@localhost` |

--- a/.devcontainer/bootstrap-kaos-control.sh
+++ b/.devcontainer/bootstrap-kaos-control.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+kaos_home="${KAOS_CONTROL_HOME:-$HOME/.kaos-control}"
+projects_dir="${KAOS_CONTROL_PROJECTS_DIR:-$kaos_home/projects}"
+data_dir="${KAOS_CONTROL_DATA_DIR:-$kaos_home/data}"
+config_file="$kaos_home/config.yaml"
+
+project_name="${KAOS_CONTROL_PROJECT_NAME:-$(basename "$repo_root")}"
+project_file="$projects_dir/$project_name.yaml"
+project_owner="${KAOS_CONTROL_PROJECT_OWNER:-$(git -C "$repo_root" config user.email || true)}"
+project_owner="${project_owner:-vscode@localhost}"
+
+mkdir -p "$projects_dir" "$data_dir"
+
+if [[ ! -f "$config_file" ]]; then
+  cat > "$config_file" <<EOF
+projects_dir: $projects_dir
+data_dir: $data_dir
+EOF
+else
+  if ! grep -Eq '^[[:space:]]*projects_dir:' "$config_file"; then
+    printf '\nprojects_dir: %s\n' "$projects_dir" >> "$config_file"
+  fi
+  if ! grep -Eq '^[[:space:]]*data_dir:' "$config_file"; then
+    printf 'data_dir: %s\n' "$data_dir" >> "$config_file"
+  fi
+fi
+
+cat > "$project_file" <<EOF
+name: $project_name
+path: $repo_root
+description: $project_name source workspace
+owner: $project_owner
+EOF
+
+printf 'kaos-control dev config bootstrapped:\n'
+printf '  config:  %s\n' "$config_file"
+printf '  project: %s\n' "$project_file"

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,24 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.7",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4",
+      "integrity": "sha256:dbf431d6b42d55cde50fa1df75c7f7c3999a90cde6d73f7a7071174b3c3d0cc4"
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "1.3.5",
+      "resolved": "ghcr.io/devcontainers/features/git@sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251",
+      "integrity": "sha256:27905dc196c01f77d6ba8709cb82eeaf330b3b108772e2f02d1cd0d826de1251"
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.3.4",
+      "resolved": "ghcr.io/devcontainers/features/go@sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032",
+      "integrity": "sha256:d85e921f91b41340055bb12b325d9d551170ed04b3b832e33530bf42f167c032"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
     "PNPM_HOME": "/home/vscode/.local/share/pnpm"
   },
   "remoteEnv": {
-    "PATH": "${containerEnv:PNPM_HOME}:${containerEnv:PATH}"
+    "PATH": "${containerEnv:PNPM_HOME}:/go/bin:${containerEnv:PATH}"
   },
   "mounts": [
     "source=kaos-control-claude,target=/home/vscode/.claude,type=volume",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,66 @@
+{
+  "name": "kaos-control",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": false,
+      "username": "vscode",
+      "upgradePackages": true
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest",
+      "ppa": true
+    },
+    "ghcr.io/devcontainers/features/go:1": {
+      "version": "1.26.3"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24.15.0",
+      "nodeGypDependencies": true
+    }
+  },
+  "remoteUser": "vscode",
+  "containerEnv": {
+    "GOTOOLCHAIN": "auto",
+    "PNPM_HOME": "/home/vscode/.local/share/pnpm"
+  },
+  "remoteEnv": {
+    "PATH": "${containerEnv:PNPM_HOME}:${containerEnv:PATH}"
+  },
+  "mounts": [
+    "source=kaos-control-claude,target=/home/vscode/.claude,type=volume",
+    "source=kaos-control-codex,target=/home/vscode/.codex,type=volume"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "forwardPorts": [
+    5173,
+    8080
+  ],
+  "portsAttributes": {
+    "5173": {
+      "label": "Vite dev server",
+      "onAutoForward": "notify"
+    },
+    "8080": {
+      "label": "kaos-control server",
+      "onAutoForward": "notify"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "anthropic.claude-code",
+        "openai.chatgpt",
+        "golang.go",
+        "Vue.volar",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "go.toolsManagement.autoUpdate": true,
+        "go.useLanguageServer": true,
+        "typescript.tsdk": "web/node_modules/typescript/lib"
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PNPM_HOME="${PNPM_HOME:-$HOME/.local/share/pnpm}"
+export PATH="$PNPM_HOME:$PATH"
+PNPM_VERSION="${PNPM_VERSION:-10.21.0}"
+mkdir -p "$PNPM_HOME"
+sudo mkdir -p "$HOME/.claude" "$HOME/.codex"
+sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude" "$HOME/.codex"
+
+corepack enable --install-directory "$PNPM_HOME"
+corepack prepare "pnpm@$PNPM_VERSION" --activate
+pnpm config set global-bin-dir "$PNPM_HOME" --global
+pnpm config set ignore-scripts false --global
+
+pnpm add --global \
+  --allow-build=@anthropic-ai/claude-code \
+  --allow-build=@openai/codex \
+  @anthropic-ai/claude-code \
+  @openai/codex
+
+CLAUDE_INSTALLER="$(pnpm root -g)/@anthropic-ai/claude-code/install.cjs"
+if [[ -f "$CLAUDE_INSTALLER" ]]; then
+  node "$CLAUDE_INSTALLER"
+fi
+
+go version
+node --version
+pnpm --version
+git --version
+claude --version
+codex --version

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,6 +19,8 @@ pnpm add --global \
   @anthropic-ai/claude-code \
   @openai/codex
 
+go install github.com/go-delve/delve/cmd/dlv@latest
+
 CLAUDE_INSTALLER="$(pnpm root -g)/@anthropic-ai/claude-code/install.cjs"
 if [[ -f "$CLAUDE_INSTALLER" ]]; then
   node "$CLAUDE_INSTALLER"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,6 +8,8 @@ mkdir -p "$PNPM_HOME"
 sudo mkdir -p "$HOME/.claude" "$HOME/.codex"
 sudo chown -R "$(id -u):$(id -g)" "$HOME/.claude" "$HOME/.codex"
 
+bash .devcontainer/bootstrap-kaos-control.sh
+
 corepack enable --install-directory "$PNPM_HOME"
 corepack prepare "pnpm@$PNPM_VERSION" --activate
 pnpm config set global-bin-dir "$PNPM_HOME" --global

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tests/e2e/node_modules/
 tests/e2e/playwright-report/
 tests/e2e/test-results/
 .vscode
+=======
+.pnpm-store/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tests/e2e/test-results/
 .vscode
 =======
 .pnpm-store/
+**/__debug_bin*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,30 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug kaos-control server",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/cmd/kaos-control",
+      "cwd": "${workspaceFolder}",
+      "args": ["serve"],
+      "env": {
+        "LOG_LEVEL": "debug"
+      },
+      "console": "internalConsole",
+      "serverReadyAction": {
+        "pattern": "\"addr\":\"(?:\\[::\\]|0\\.0\\.0\\.0|127\\.0\\.0\\.1|localhost):(\\d+)\"",
+        "uriFormat": "http://localhost:%s",
+        "action": "openExternally"
+      }
+    },
+    {
+      "name": "Debug current Go test",
+      "type": "go",
+      "request": "launch",
+      "mode": "test",
+      "program": "${fileDirname}"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -240,6 +240,12 @@ Alternatives:
 
 Verify: `pnpm --version` should print `9.x` or higher.
 
+### Windows / WSL development
+
+On Windows, develop from WSL and clone this repository into the Linux filesystem, not a Windows-mounted drive. For example, use a path like `~/src/kaos-control` or `/workspaces/kaos-control`, and avoid `/mnt/c/...`.
+
+Keeping the repo off the Windows drive prevents common file-watching, permissions, symlink, and dependency install issues with Go, Node.js, Vite, and pnpm.
+
 ### 1. Build the binary
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -246,6 +246,10 @@ On Windows, develop from WSL and clone this repository into the Linux filesystem
 
 Keeping the repo off the Windows drive prevents common file-watching, permissions, symlink, and dependency install issues with Go, Node.js, Vite, and pnpm.
 
+### Dev container
+
+VS Code dev container setup is documented in [.devcontainer/README.md](.devcontainer/README.md). The container post-create hook installs project tooling and bootstraps a minimal `~/.kaos-control` config that registers this workspace as a project.
+
 ### 1. Build the binary
 
 ```sh


### PR DESCRIPTION
## Summary
- Add a VS Code devcontainer with Go, Node, pnpm, Claude Code, Codex, and Delve tooling.
- Bootstrap a local kaos-control config/project entry for the checked-out workspace.
- Document devcontainer setup, forwarded ports, and bootstrap overrides.

## Testing
- Tested devcontainer on Windows 11 + WSL using Docker.
- Tested devcontainer on macOS using Docker.
- Locally validated JSON parsing for `.devcontainer/devcontainer.json` and `.devcontainer/devcontainer-lock.json`.
- Ran `bash -n` for `.devcontainer/post-create.sh` and `.devcontainer/bootstrap-kaos-control.sh`.
- Ran `git diff --check upstream/main...HEAD`.