### PR TITLE
feat: Add llama.cpp driver for local model support

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,34 @@
+## Kaos Control development
+
+# Build frontend and backend
+build:
+	cd web && pnpm run build
+	go build -p 1 -ldflags "-X main.version=0.3.0 -X github.com/kaos-control/kaos-control/internal/http.Version=0.3.0" -o ./dist/kaos-control ./cmd/kaos-control
+
+# Run everything in dev mode
+dev:
+	@echo "Starting both backend and frontend in dev mode..."
+	@echo "Backend will run on http://localhost:4000"
+	@echo "Frontend dev server will run on http://localhost:5173"
+	@echo ""
+	@echo "Run in separate terminals or use background jobs."
+	@echo ""
+	@echo "Backend:  just dev-backend"
+	@echo "Frontend: just dev-web"
+
+# Backend dev mode (go run with hot reload)
+dev-backend:
+	LOG_LEVEL=debug go run ./cmd/kaos-control -d
+
+# Frontend dev mode (Vite dev server)
+dev-web:
+	cd web && pnpm run dev
+
+# Run built binary
+run:
+	./dist/kaos-control -d
+
+# Clean build artifacts
+clean:
+	rm -f ./dist/kaos-control
+	rm -rf web/dist

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -93,7 +93,13 @@ type Run struct {
 	// Ollama-specific fields (only used when Driver == "ollama").
 	OllamaInstanceName string // resolved from AgentConfig.OllamaInstanceName
 	OllamaEndpoint     string // "chat" or "generate"
-	ShellCommand       string // shell-stub driver: command to run (empty = default stub behavior)
+	// Llama.cpp-specific fields (only used when Driver == "llama.cpp").
+	LlamaCPPInstanceName string // resolved from AgentConfig.LlamaCPPInstanceName
+	// ShellCommand is shell-stub driver: command to run (empty = default stub behavior).
+	ShellCommand string
+	// Llama.cpp inference params (only used when Driver == "llama.cpp").
+	MaxTokens     int     // max tokens to generate (0 = model default)
+	Temperature   float64 // temperature for sampling (0.0 = greedy)
 	// claude-env driver fields (only used when Driver == "claude-env").
 	BaseURL   string // ANTHROPIC_BASE_URL override for the subprocess
 	AuthToken string // ANTHROPIC_AUTH_TOKEN override — secret, must never be logged or echoed
@@ -445,8 +451,9 @@ func New(
 	wf WorkflowEngine,
 	root string,
 	logsDir string,
-	ollamaInstances []config.OllamaInstance,
-	agentCfg config.AppAgentConfig,
+	ollamaInstances   []config.OllamaInstance,
+	llamaCPPInstances []config.LlamaCPPInstance,
+	agentCfg          config.AppAgentConfig,
 ) *Manager {
 	if maxConcurrent <= 0 {
 		maxConcurrent = 4
@@ -489,6 +496,7 @@ func New(
 		"claude-env":      &ClaudeEnvDriver{},
 		"codex-cli":       &CodexCLIDriver{},
 		"ollama":          &OllamaDriver{Instances: ollamaInstances},
+		"llama.cpp":       &LlamaCPPDriver{Instances: llamaCPPInstances},
 		"gemini":          &GeminiDriver{},
 		"gemini-cli":      &GeminiCliDriver{},
 		"shell-stub":      &ShellStubDriver{},
@@ -633,12 +641,15 @@ func (m *Manager) StartRun(ctx context.Context, agentName, targetPath, role stri
 		ActiveStatus:       ag.ActiveStatus,
 		DoneOnSuccess:      ag.DoneOnSuccess,
 		TimeoutMinutes:     ag.TimeoutMinutes,
-		RelatedTestPath:    relatedTestPath,
-		OllamaInstanceName: ag.OllamaInstanceName,
-		OllamaEndpoint:     ag.OllamaEndpoint,
-		ShellCommand:       ag.ShellCommand,
-		BaseURL:            ag.BaseURL,
-		AuthToken:          ag.AuthToken,
+		RelatedTestPath:      relatedTestPath,
+		OllamaInstanceName:   ag.OllamaInstanceName,
+		OllamaEndpoint:       ag.OllamaEndpoint,
+		LlamaCPPInstanceName: ag.LlamaCPPInstanceName,
+		MaxTokens:            ag.MaxTokens,
+		Temperature:          ag.Temperature,
+		ShellCommand:         ag.ShellCommand,
+		BaseURL:              ag.BaseURL,
+		AuthToken:            ag.AuthToken,
 	}
 
 	// Wire TTFT recording for streaming drivers. The callback is called from

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -98,8 +98,8 @@ type Run struct {
 	// ShellCommand is shell-stub driver: command to run (empty = default stub behavior).
 	ShellCommand string
 	// Llama.cpp inference params (only used when Driver == "llama.cpp").
-	MaxTokens     int     // max tokens to generate (0 = model default)
-	Temperature   float64 // temperature for sampling (0.0 = greedy)
+	MaxTokens   int     // max tokens to generate (0 = model default)
+	Temperature float64 // temperature for sampling (0.0 = greedy)
 	// claude-env driver fields (only used when Driver == "claude-env").
 	BaseURL   string // ANTHROPIC_BASE_URL override for the subprocess
 	AuthToken string // ANTHROPIC_AUTH_TOKEN override — secret, must never be logged or echoed
@@ -451,9 +451,9 @@ func New(
 	wf WorkflowEngine,
 	root string,
 	logsDir string,
-	ollamaInstances   []config.OllamaInstance,
+	ollamaInstances []config.OllamaInstance,
 	llamaCPPInstances []config.LlamaCPPInstance,
-	agentCfg          config.AppAgentConfig,
+	agentCfg config.AppAgentConfig,
 ) *Manager {
 	if maxConcurrent <= 0 {
 		maxConcurrent = 4
@@ -627,20 +627,20 @@ func (m *Manager) StartRun(ctx context.Context, agentName, targetPath, role stri
 	}
 
 	run := Run{
-		RunID:              runID,
-		AgentName:          agentName,
-		Role:               role,
-		Driver:             ag.Driver,
-		Model:              ag.Model,
-		PromptText:         prompt,
-		ProjectRoot:        m.root,
-		AllowedPaths:       ag.AllowedPaths,
-		GitIdentity:        identity,
-		LogPath:            m.LogPath(runID),
-		TargetPath:         targetPath,
-		ActiveStatus:       ag.ActiveStatus,
-		DoneOnSuccess:      ag.DoneOnSuccess,
-		TimeoutMinutes:     ag.TimeoutMinutes,
+		RunID:                runID,
+		AgentName:            agentName,
+		Role:                 role,
+		Driver:               ag.Driver,
+		Model:                ag.Model,
+		PromptText:           prompt,
+		ProjectRoot:          m.root,
+		AllowedPaths:         ag.AllowedPaths,
+		GitIdentity:          identity,
+		LogPath:              m.LogPath(runID),
+		TargetPath:           targetPath,
+		ActiveStatus:         ag.ActiveStatus,
+		DoneOnSuccess:        ag.DoneOnSuccess,
+		TimeoutMinutes:       ag.TimeoutMinutes,
 		RelatedTestPath:      relatedTestPath,
 		OllamaInstanceName:   ag.OllamaInstanceName,
 		OllamaEndpoint:       ag.OllamaEndpoint,

--- a/internal/agent/llama_cpp.go
+++ b/internal/agent/llama_cpp.go
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/kaos-control/kaos-control/internal/config"
+)
+
+// LlamaCPPDriver implements Driver by sending requests to a llama.cpp server.
+type LlamaCPPDriver struct {
+	Instances  []config.LlamaCPPInstance
+	HTTPClient *http.Client
+}
+
+// llamaCPPProcess implements Process for a streaming llama.cpp request.
+type llamaCPPProcess struct {
+	cancel   context.CancelFunc
+	progress chan ProgressEvent
+	stderr   *ringBuf
+	done     chan error
+}
+
+func (p *llamaCPPProcess) Wait() error              { return <-p.done }
+func (p *llamaCPPProcess) Progress() <-chan ProgressEvent { return p.progress }
+func (p *llamaCPPProcess) StderrTail() string       { return p.stderr.String() }
+func (p *llamaCPPProcess) Kill() error {
+	p.cancel()
+	return nil
+}
+
+// Start implements Driver. It resolves the instance, builds the request body,
+// and spawns a goroutine to stream response tokens.
+func (d *LlamaCPPDriver) Start(ctx context.Context, run Run) (Process, error) {
+	// Resolve the instance by name.
+	instanceName := run.LlamaCPPInstanceName
+	var inst *config.LlamaCPPInstance
+	for i := range d.Instances {
+		if d.Instances[i].Name == instanceName {
+			inst = &d.Instances[i]
+			break
+		}
+	}
+	if inst == nil {
+		return nil, fmt.Errorf("llama.cpp instance %q not found", instanceName)
+	}
+
+	// Separate system and user prompts.
+	systemPrompt, userPrompt := splitPrompt(run.PromptText)
+
+	// Apply defaults for inference params.
+	maxTokens := run.MaxTokens
+	if maxTokens <= 0 {
+		maxTokens = 4096 // reasonable default
+	}
+	temperature := run.Temperature
+	if temperature <= 0 {
+		temperature = 0.7 // reasonable default
+	}
+
+	// Build JSON body for chat completion.
+	body := map[string]any{
+		"model":       run.Model,
+		"messages":    []map[string]any{},
+		"stream":      true,
+		"max_tokens":  maxTokens,
+		"temperature": temperature,
+	}
+
+	if systemPrompt != "" {
+		body["messages"] = append(body["messages"].([]map[string]any), map[string]any{
+			"role":    "system",
+			"content": systemPrompt,
+		})
+	}
+	body["messages"] = append(body["messages"].([]map[string]any), map[string]any{
+		"role":    "user",
+		"content": userPrompt,
+	})
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling llama.cpp request: %w", err)
+	}
+
+	// Build HTTP request.
+	apiURL := inst.BaseURL + "/v1/chat/completions"
+	httpReq, err := http.NewRequest(http.MethodPost, apiURL, strings.NewReader(string(bodyBytes)))
+	if err != nil {
+		return nil, fmt.Errorf("building llama.cpp http request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if inst.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+inst.APIKey)
+	}
+
+	// Timeout: use TimeoutMinutes from run (0 → 5 minutes default).
+	timeout := time.Duration(run.TimeoutMinutes) * time.Minute
+	if timeout <= 0 {
+		timeout = 5 * time.Minute
+	}
+	runCtx, cancel := context.WithTimeout(ctx, timeout)
+	httpReq = httpReq.WithContext(runCtx)
+
+	rb := newRingBuf(4 * 1024)
+	progressCh := make(chan ProgressEvent, 64)
+	doneCh := make(chan error, 1)
+
+	proc := &llamaCPPProcess{
+		cancel:   cancel,
+		progress: progressCh,
+		stderr:   rb,
+		done:     doneCh,
+	}
+
+	client := d.HTTPClient
+	if client == nil {
+		client = &http.Client{}
+	}
+
+	// Open the per-run log file if configured.
+	var logFile *os.File
+	if run.LogPath != "" {
+		if err := os.MkdirAll(filepath.Dir(run.LogPath), 0o755); err != nil {
+			slog.Warn("llama.cpp agent: creating log dir failed", "path", run.LogPath, "err", err)
+		} else if f, err := os.OpenFile(run.LogPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644); err != nil {
+			slog.Warn("llama.cpp agent: opening log file failed", "path", run.LogPath, "err", err)
+		} else {
+			logFile = f
+			fmt.Fprintf(logFile, "# kaos-control agent run %s\n# agent=%s role=%s driver=llama.cpp instance=%s model=%s\n# started=%s\n",
+				run.RunID, run.AgentName, run.Role, instanceName, run.Model, time.Now().Format(time.RFC3339))
+			if systemPrompt != "" {
+				fmt.Fprintf(logFile, "\n# system_prompt:\n%s\n", systemPrompt)
+			}
+			fmt.Fprintf(logFile, "\n# user_prompt:\n%s\n\n", userPrompt)
+		}
+	}
+
+	writeLog := func(s string) {
+		if logFile != nil {
+			_, _ = logFile.WriteString(s)
+			if !strings.HasSuffix(s, "\n") {
+				_, _ = logFile.WriteString("\n")
+			}
+		}
+	}
+
+	go func() {
+		defer cancel()
+		defer close(progressCh)
+		defer func() {
+			if logFile != nil {
+				fmt.Fprintf(logFile, "\n# finished=%s\n", time.Now().Format(time.RFC3339))
+				_ = logFile.Close()
+			}
+		}()
+
+		writeLog("# event: started")
+		select {
+		case progressCh <- ProgressEvent{Raw: "started"}:
+		default:
+		}
+
+		resp, err := client.Do(httpReq)
+		if err != nil {
+			rb.Write([]byte(err.Error()))
+			writeLog("# error: " + err.Error())
+			doneCh <- err
+			return
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			msg := fmt.Sprintf("llama.cpp returned HTTP %d", resp.StatusCode)
+			rb.Write([]byte(msg))
+			writeLog("# error: " + msg)
+			doneCh <- fmt.Errorf("%s", msg)
+			return
+		}
+
+		// Stream JSON response chunks.
+		var fullResponse strings.Builder
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+		for sc.Scan() {
+			line := sc.Text()
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, "data: ") {
+				line = line[6:]
+			}
+			writeLog(line)
+
+			var chunk map[string]any
+			if err := json.Unmarshal([]byte(line), &chunk); err != nil {
+				continue
+			}
+
+			ev := ProgressEvent{Raw: line, Event: chunk}
+
+			// Accumulate response text.
+			if choices, ok := chunk["choices"].([]any); ok && len(choices) > 0 {
+				if choice, ok := choices[0].(map[string]any); ok {
+					if delta, ok := choice["delta"].(map[string]any); ok {
+						if content, ok := delta["content"].(string); ok {
+							fullResponse.WriteString(content)
+						}
+					}
+				}
+			}
+
+			select {
+			case progressCh <- ev:
+			default:
+			}
+
+			// Check for completion.
+			if done, ok := chunk["done"].(bool); ok && done {
+				continue
+			}
+		}
+
+		if scanErr := sc.Err(); scanErr != nil {
+			rb.Write([]byte(scanErr.Error()))
+			writeLog("# error: " + scanErr.Error())
+			doneCh <- scanErr
+			return
+		}
+
+		// Emit completed event with full response.
+		completed := ProgressEvent{
+			Raw: "completed",
+			Event: map[string]any{
+				"type":     "completed",
+				"response": fullResponse.String(),
+			},
+		}
+		writeLog("# event: completed")
+		writeLog(fullResponse.String())
+		select {
+		case progressCh <- completed:
+		default:
+		}
+
+		doneCh <- nil
+	}()
+
+	return proc, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,12 +23,18 @@ type OllamaInstance struct {
 	APIKey  string `yaml:"api_key,omitempty"`
 }
 
+func (o OllamaInstance) instanceName() string    { return o.Name }
+func (o OllamaInstance) instanceBaseURL() string { return o.BaseURL }
+
 // LlamaCPPInstance is one registered llama.cpp server shared across all projects.
 type LlamaCPPInstance struct {
 	Name    string `yaml:"name"`
 	BaseURL string `yaml:"base_url"`
 	APIKey  string `yaml:"api_key,omitempty"`
 }
+
+func (l LlamaCPPInstance) instanceName() string    { return l.Name }
+func (l LlamaCPPInstance) instanceBaseURL() string { return l.BaseURL }
 
 // App is the top-level application configuration (install-dir/config.yaml).
 type App struct {
@@ -150,28 +156,29 @@ func LoadApp(path string) (*App, error) {
 	return &cfg, nil
 }
 
+
+
 // validateInstances checks that each instance has a unique name and valid URL.
 // Returns an error describing the first validation failure encountered.
-func validateInstances(namePrefix string, instances []struct {
-	Name    string
-	BaseURL string
-}) error {
+func validateInstances[T interface{ instanceName() string; instanceBaseURL() string }](namePrefix string, instances []T) error {
 	seen := make(map[string]bool)
 	for i, inst := range instances {
-		if inst.Name == "" {
+		name := inst.instanceName()
+		baseURL := inst.instanceBaseURL()
+		if name == "" {
 			return fmt.Errorf("%s[%d]: name must not be empty", namePrefix, i)
 		}
-		if seen[inst.Name] {
-			return fmt.Errorf("%s: duplicate name %q", namePrefix, inst.Name)
+		if baseURL == "" {
+			return fmt.Errorf("%s[%d] %q: base_url must not be empty", namePrefix, i, name)
 		}
-		seen[inst.Name] = true
-		if inst.BaseURL == "" {
-			return fmt.Errorf("%s[%d] %q: base_url must not be empty", namePrefix, i, inst.Name)
-		}
-		u, err := url.ParseRequestURI(inst.BaseURL)
+		u, err := url.ParseRequestURI(baseURL)
 		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("%s[%d] %q: base_url %q is not a valid http/https URL", namePrefix, i, inst.Name, inst.BaseURL)
+			return fmt.Errorf("%s[%d] %q: base_url %q is not a valid http/https URL", namePrefix, i, name, baseURL)
 		}
+		if seen[name] {
+			return fmt.Errorf("%s: duplicate name %q", namePrefix, name)
+		}
+		seen[name] = true
 	}
 	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,15 +23,23 @@ type OllamaInstance struct {
 	APIKey  string `yaml:"api_key,omitempty"`
 }
 
+// LlamaCPPInstance is one registered llama.cpp server shared across all projects.
+type LlamaCPPInstance struct {
+	Name    string `yaml:"name"`
+	BaseURL string `yaml:"base_url"`
+	APIKey  string `yaml:"api_key,omitempty"`
+}
+
 // App is the top-level application configuration (install-dir/config.yaml).
 type App struct {
-	Server          ServerConfig     `yaml:"server"`
-	Auth            AuthConfig       `yaml:"auth"`
-	ProjectsDir     string           `yaml:"projects_dir"`
-	Limits          LimitsConfig     `yaml:"limits"`
-	DataDir         string           `yaml:"data_dir"` // where app DBs live; defaults to projects_dir/../data
-	OllamaInstances []OllamaInstance `yaml:"ollama_instances,omitempty"`
-	Agent           AppAgentConfig   `yaml:"agent"`
+	Server            ServerConfig     `yaml:"server"`
+	Auth              AuthConfig       `yaml:"auth"`
+	ProjectsDir       string           `yaml:"projects_dir"`
+	Limits            LimitsConfig     `yaml:"limits"`
+	DataDir           string           `yaml:"data_dir"` // where app DBs live; defaults to projects_dir/../data
+	OllamaInstances   []OllamaInstance `yaml:"ollama_instances,omitempty"`
+	LlamaCPPInstances []LlamaCPPInstance `yaml:"llama_cpp_instances,omitempty"`
+	Agent             AppAgentConfig   `yaml:"agent"`
 }
 
 type ServerConfig struct {
@@ -175,7 +183,7 @@ func validateApp(cfg *App) error {
 		cfg.Agent.RequireBypassPermissions = &v
 	}
 
-	seen := make(map[string]bool, len(cfg.OllamaInstances))
+	seen := make(map[string]bool, len(cfg.OllamaInstances)+len(cfg.LlamaCPPInstances))
 	for i, inst := range cfg.OllamaInstances {
 		if inst.Name == "" {
 			return fmt.Errorf("ollama_instances[%d]: name must not be empty", i)
@@ -190,6 +198,22 @@ func validateApp(cfg *App) error {
 		u, err := url.ParseRequestURI(inst.BaseURL)
 		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
 			return fmt.Errorf("ollama_instances[%d] %q: base_url %q is not a valid http/https URL", i, inst.Name, inst.BaseURL)
+		}
+	}
+	for i, inst := range cfg.LlamaCPPInstances {
+		if inst.Name == "" {
+			return fmt.Errorf("llama_cpp_instances[%d]: name must not be empty", i)
+		}
+		if seen[inst.Name] {
+			return fmt.Errorf("llama_cpp_instances: duplicate name %q", inst.Name)
+		}
+		seen[inst.Name] = true
+		if inst.BaseURL == "" {
+			return fmt.Errorf("llama_cpp_instances[%d] %q: base_url must not be empty", i, inst.Name)
+		}
+		u, err := url.ParseRequestURI(inst.BaseURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("llama_cpp_instances[%d] %q: base_url %q is not a valid http/https URL", i, inst.Name, inst.BaseURL)
 		}
 	}
 	return nil
@@ -463,6 +487,8 @@ type AgentConfig struct {
 	// Ollama-specific fields (only used when Driver == "ollama").
 	OllamaInstanceName string `yaml:"ollama_instance,omitempty"` // name of OllamaInstance in app config
 	OllamaEndpoint     string `yaml:"ollama_endpoint,omitempty"` // "chat" (default) or "generate"
+	// Llama.cpp-specific fields (only used when Driver == "llama.cpp").
+	LlamaCPPInstanceName string `yaml:"llama_cpp_instance,omitempty"` // name of LlamaCPPInstance in app config
 	// claude-mediated driver fields.
 	// BashAllowlist is a list of glob patterns; when non-empty only matching
 	// commands are permitted. Checked after BashDenylist.
@@ -480,6 +506,9 @@ type AgentConfig struct {
 	// It is the shell command to run as the agent process.
 	// If empty, the stub emits one synthetic result event and exits 0.
 	ShellCommand string `yaml:"shell_command,omitempty"`
+	// Llama.cpp inference params (only used when Driver == "llama.cpp").
+	MaxTokens     int     `yaml:"max_tokens,omitempty"`     // max tokens to generate (0 = model default)
+	Temperature   float64 `yaml:"temperature,omitempty"`    // temperature for sampling (0.0 = greedy)
 	// claude-env driver fields (only used when Driver == "claude-env").
 	BaseURL   string `yaml:"base_url,omitempty"`
 	AuthToken string `yaml:"auth_token,omitempty"` // secret — must never be logged or echoed
@@ -501,13 +530,16 @@ type agentConfigRaw struct {
 	ActiveStatus       string            `yaml:"active_status,omitempty"`
 	DoneOnSuccess      bool              `yaml:"done_on_success,omitempty"`
 	SourceTypes        []string          `yaml:"source_types,omitempty"`
-	OllamaInstanceName string            `yaml:"ollama_instance,omitempty"`
-	OllamaEndpoint     string            `yaml:"ollama_endpoint,omitempty"`
-	BashAllowlist      []string          `yaml:"bash_allowlist,omitempty"`
+	OllamaInstanceName   string            `yaml:"ollama_instance,omitempty"`
+	OllamaEndpoint       string            `yaml:"ollama_endpoint,omitempty"`
+	LlamaCPPInstanceName string            `yaml:"llama_cpp_instance,omitempty"`
+	BashAllowlist        []string          `yaml:"bash_allowlist,omitempty"`
 	BashDenylist       []string          `yaml:"bash_denylist,omitempty"`
 	OnDenial           string            `yaml:"on_denial,omitempty"`
 	ObserveOnly        bool              `yaml:"observe_only,omitempty"`
 	ShellCommand       string            `yaml:"shell_command,omitempty"`
+	MaxTokens          int               `yaml:"max_tokens,omitempty"`
+	Temperature        float64           `yaml:"temperature,omitempty"`
 	BaseURL            string            `yaml:"base_url,omitempty"`
 	AuthToken          string            `yaml:"auth_token,omitempty"`
 }
@@ -533,12 +565,15 @@ func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
 	a.SourceTypes = raw.SourceTypes
 	a.OllamaInstanceName = raw.OllamaInstanceName
 	a.OllamaEndpoint = raw.OllamaEndpoint
+	a.LlamaCPPInstanceName = raw.LlamaCPPInstanceName
 	a.BashAllowlist = raw.BashAllowlist
 	a.BashDenylist = raw.BashDenylist
 	a.OnDenial = raw.OnDenial
 	a.ObserveOnly = raw.ObserveOnly
-	a.ShellCommand = raw.ShellCommand
-	a.BaseURL = raw.BaseURL
+	a.ShellCommand         = raw.ShellCommand
+	a.MaxTokens            = raw.MaxTokens
+	a.Temperature          = raw.Temperature
+	a.BaseURL              = raw.BaseURL
 	a.AuthToken = raw.AuthToken
 
 	// Merge "role" and "roles" entries, preserving order and deduplicating.
@@ -989,6 +1024,14 @@ func validateProject(cfg *Project) error {
 				a.OllamaEndpoint = "chat"
 			} else if a.OllamaEndpoint != "chat" && a.OllamaEndpoint != "generate" {
 				return fmt.Errorf("project config: agent %q ollama_endpoint must be \"chat\" or \"generate\", got %q", a.Name, a.OllamaEndpoint)
+			}
+		}
+		if a.Driver == "llama.cpp" {
+			if a.LlamaCPPInstanceName == "" {
+				return fmt.Errorf("project config: agent %q has driver=llama.cpp but missing llama_cpp_instance", a.Name)
+			}
+			if a.Model == "" {
+				return fmt.Errorf("project config: agent %q has driver=llama.cpp but missing model", a.Name)
 			}
 		}
 		if a.Driver == "claude-mediated" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,14 +32,14 @@ type LlamaCPPInstance struct {
 
 // App is the top-level application configuration (install-dir/config.yaml).
 type App struct {
-	Server            ServerConfig     `yaml:"server"`
-	Auth              AuthConfig       `yaml:"auth"`
-	ProjectsDir       string           `yaml:"projects_dir"`
-	Limits            LimitsConfig     `yaml:"limits"`
-	DataDir           string           `yaml:"data_dir"` // where app DBs live; defaults to projects_dir/../data
-	OllamaInstances   []OllamaInstance `yaml:"ollama_instances,omitempty"`
+	Server            ServerConfig       `yaml:"server"`
+	Auth              AuthConfig         `yaml:"auth"`
+	ProjectsDir       string             `yaml:"projects_dir"`
+	Limits            LimitsConfig       `yaml:"limits"`
+	DataDir           string             `yaml:"data_dir"` // where app DBs live; defaults to projects_dir/../data
+	OllamaInstances   []OllamaInstance   `yaml:"ollama_instances,omitempty"`
 	LlamaCPPInstances []LlamaCPPInstance `yaml:"llama_cpp_instances,omitempty"`
-	Agent             AppAgentConfig   `yaml:"agent"`
+	Agent             AppAgentConfig     `yaml:"agent"`
 }
 
 type ServerConfig struct {
@@ -150,6 +150,32 @@ func LoadApp(path string) (*App, error) {
 	return &cfg, nil
 }
 
+// validateInstances checks that each instance has a unique name and valid URL.
+// Returns an error describing the first validation failure encountered.
+func validateInstances(namePrefix string, instances []struct {
+	Name    string
+	BaseURL string
+}) error {
+	seen := make(map[string]bool)
+	for i, inst := range instances {
+		if inst.Name == "" {
+			return fmt.Errorf("%s[%d]: name must not be empty", namePrefix, i)
+		}
+		if seen[inst.Name] {
+			return fmt.Errorf("%s: duplicate name %q", namePrefix, inst.Name)
+		}
+		seen[inst.Name] = true
+		if inst.BaseURL == "" {
+			return fmt.Errorf("%s[%d] %q: base_url must not be empty", namePrefix, i, inst.Name)
+		}
+		u, err := url.ParseRequestURI(inst.BaseURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return fmt.Errorf("%s[%d] %q: base_url %q is not a valid http/https URL", namePrefix, i, inst.Name, inst.BaseURL)
+		}
+	}
+	return nil
+}
+
 func validateApp(cfg *App) error {
 	if cfg.Server.Listen == "" {
 		return fmt.Errorf("server.listen must not be empty")
@@ -183,38 +209,11 @@ func validateApp(cfg *App) error {
 		cfg.Agent.RequireBypassPermissions = &v
 	}
 
-	seen := make(map[string]bool, len(cfg.OllamaInstances)+len(cfg.LlamaCPPInstances))
-	for i, inst := range cfg.OllamaInstances {
-		if inst.Name == "" {
-			return fmt.Errorf("ollama_instances[%d]: name must not be empty", i)
-		}
-		if seen[inst.Name] {
-			return fmt.Errorf("ollama_instances: duplicate name %q", inst.Name)
-		}
-		seen[inst.Name] = true
-		if inst.BaseURL == "" {
-			return fmt.Errorf("ollama_instances[%d] %q: base_url must not be empty", i, inst.Name)
-		}
-		u, err := url.ParseRequestURI(inst.BaseURL)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("ollama_instances[%d] %q: base_url %q is not a valid http/https URL", i, inst.Name, inst.BaseURL)
-		}
+	if err := validateInstances("ollama_instances", cfg.OllamaInstances); err != nil {
+		return err
 	}
-	for i, inst := range cfg.LlamaCPPInstances {
-		if inst.Name == "" {
-			return fmt.Errorf("llama_cpp_instances[%d]: name must not be empty", i)
-		}
-		if seen[inst.Name] {
-			return fmt.Errorf("llama_cpp_instances: duplicate name %q", inst.Name)
-		}
-		seen[inst.Name] = true
-		if inst.BaseURL == "" {
-			return fmt.Errorf("llama_cpp_instances[%d] %q: base_url must not be empty", i, inst.Name)
-		}
-		u, err := url.ParseRequestURI(inst.BaseURL)
-		if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
-			return fmt.Errorf("llama_cpp_instances[%d] %q: base_url %q is not a valid http/https URL", i, inst.Name, inst.BaseURL)
-		}
+	if err := validateInstances("llama_cpp_instances", cfg.LlamaCPPInstances); err != nil {
+		return err
 	}
 	return nil
 }
@@ -507,8 +506,8 @@ type AgentConfig struct {
 	// If empty, the stub emits one synthetic result event and exits 0.
 	ShellCommand string `yaml:"shell_command,omitempty"`
 	// Llama.cpp inference params (only used when Driver == "llama.cpp").
-	MaxTokens     int     `yaml:"max_tokens,omitempty"`     // max tokens to generate (0 = model default)
-	Temperature   float64 `yaml:"temperature,omitempty"`    // temperature for sampling (0.0 = greedy)
+	MaxTokens   int     `yaml:"max_tokens,omitempty"`  // max tokens to generate (0 = model default)
+	Temperature float64 `yaml:"temperature,omitempty"` // temperature for sampling (0.0 = greedy)
 	// claude-env driver fields (only used when Driver == "claude-env").
 	BaseURL   string `yaml:"base_url,omitempty"`
 	AuthToken string `yaml:"auth_token,omitempty"` // secret — must never be logged or echoed
@@ -517,31 +516,31 @@ type AgentConfig struct {
 // agentConfigRaw is used internally to unmarshal AgentConfig and accept both
 // "role" (canonical) and "roles" (alias) YAML keys for the roles list.
 type agentConfigRaw struct {
-	Name               string            `yaml:"name"`
-	Role               []string          `yaml:"role"`
-	Roles              []string          `yaml:"roles"`
-	Driver             string            `yaml:"driver"`
-	Model              string            `yaml:"model,omitempty"`
-	Endpoint           string            `yaml:"endpoint,omitempty"`
-	AllowedPaths       []string          `yaml:"allowed_write_paths,omitempty"`
-	TimeoutMinutes     int               `yaml:"timeout_minutes,omitempty"`
-	GitIdentity        GitIdentity       `yaml:"git_identity"`
-	PromptTemplates    map[string]string `yaml:"prompt_templates,omitempty"`
-	ActiveStatus       string            `yaml:"active_status,omitempty"`
-	DoneOnSuccess      bool              `yaml:"done_on_success,omitempty"`
-	SourceTypes        []string          `yaml:"source_types,omitempty"`
+	Name                 string            `yaml:"name"`
+	Role                 []string          `yaml:"role"`
+	Roles                []string          `yaml:"roles"`
+	Driver               string            `yaml:"driver"`
+	Model                string            `yaml:"model,omitempty"`
+	Endpoint             string            `yaml:"endpoint,omitempty"`
+	AllowedPaths         []string          `yaml:"allowed_write_paths,omitempty"`
+	TimeoutMinutes       int               `yaml:"timeout_minutes,omitempty"`
+	GitIdentity          GitIdentity       `yaml:"git_identity"`
+	PromptTemplates      map[string]string `yaml:"prompt_templates,omitempty"`
+	ActiveStatus         string            `yaml:"active_status,omitempty"`
+	DoneOnSuccess        bool              `yaml:"done_on_success,omitempty"`
+	SourceTypes          []string          `yaml:"source_types,omitempty"`
 	OllamaInstanceName   string            `yaml:"ollama_instance,omitempty"`
 	OllamaEndpoint       string            `yaml:"ollama_endpoint,omitempty"`
 	LlamaCPPInstanceName string            `yaml:"llama_cpp_instance,omitempty"`
 	BashAllowlist        []string          `yaml:"bash_allowlist,omitempty"`
-	BashDenylist       []string          `yaml:"bash_denylist,omitempty"`
-	OnDenial           string            `yaml:"on_denial,omitempty"`
-	ObserveOnly        bool              `yaml:"observe_only,omitempty"`
-	ShellCommand       string            `yaml:"shell_command,omitempty"`
-	MaxTokens          int               `yaml:"max_tokens,omitempty"`
-	Temperature        float64           `yaml:"temperature,omitempty"`
-	BaseURL            string            `yaml:"base_url,omitempty"`
-	AuthToken          string            `yaml:"auth_token,omitempty"`
+	BashDenylist         []string          `yaml:"bash_denylist,omitempty"`
+	OnDenial             string            `yaml:"on_denial,omitempty"`
+	ObserveOnly          bool              `yaml:"observe_only,omitempty"`
+	ShellCommand         string            `yaml:"shell_command,omitempty"`
+	MaxTokens            int               `yaml:"max_tokens,omitempty"`
+	Temperature          float64           `yaml:"temperature,omitempty"`
+	BaseURL              string            `yaml:"base_url,omitempty"`
+	AuthToken            string            `yaml:"auth_token,omitempty"`
 }
 
 // UnmarshalYAML implements yaml.Unmarshaler so that AgentConfig accepts both
@@ -570,10 +569,10 @@ func (a *AgentConfig) UnmarshalYAML(value *yaml.Node) error {
 	a.BashDenylist = raw.BashDenylist
 	a.OnDenial = raw.OnDenial
 	a.ObserveOnly = raw.ObserveOnly
-	a.ShellCommand         = raw.ShellCommand
-	a.MaxTokens            = raw.MaxTokens
-	a.Temperature          = raw.Temperature
-	a.BaseURL              = raw.BaseURL
+	a.ShellCommand = raw.ShellCommand
+	a.MaxTokens = raw.MaxTokens
+	a.Temperature = raw.Temperature
+	a.BaseURL = raw.BaseURL
 	a.AuthToken = raw.AuthToken
 
 	// Merge "role" and "roles" entries, preserving order and deduplicating.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -63,8 +63,9 @@ type OpenOptions struct {
 	MaxConcurrentAgents        int
 	MaxConcurrentSchedulerJobs int
 	SchedulerRunRetentionDays  int
-	OllamaInstances            []config.OllamaInstance // app-level Ollama servers for OllamaDriver
-	AgentCfg                   config.AppAgentConfig   // precheck timeout + bypass-permissions flag
+	OllamaInstances            []config.OllamaInstance     // app-level Ollama servers for OllamaDriver
+	LlamaCPPInstances          []config.LlamaCPPInstance   // app-level llama.cpp servers for LlamaCPPDriver
+	AgentCfg                   config.AppAgentConfig       // precheck timeout + bypass-permissions flag
 
 	// DevopsLogDir is the base directory for pipeline run logs.
 	// Logs are stored at DevopsLogDir/<project-name>/<run_id>.log.
@@ -200,7 +201,7 @@ func Open(entry *config.ProjectEntry, dbDir string, opts OpenOptions) (*Project,
 	var agentMgr *agent.Manager
 	if len(cfg.Agents) > 0 {
 		runsLogDir := filepath.Join(dbDir, entry.Name, "runs")
-		agentMgr = agent.New(cfg.Agents, maxConcurrent, idx, gitRepo, h, locks, wf, entry.Path, runsLogDir, opts.OllamaInstances, opts.AgentCfg)
+		agentMgr = agent.New(cfg.Agents, maxConcurrent, idx, gitRepo, h, locks, wf, entry.Path, runsLogDir, opts.OllamaInstances, opts.LlamaCPPInstances, opts.AgentCfg)
 		if opts.HookServerAddr != "" {
 			agentMgr.ConfigureHookDriver(opts.HookServerAddr, opts.HookBinaryPath)
 		}

--- a/lifecycle/config.yaml
+++ b/lifecycle/config.yaml
@@ -394,6 +394,63 @@ agents:
             - role: product-owner
               who: agent
         Then stop — do not commit partial code.
+  - name: backend-developer
+    role:
+      - backend-developer
+    driver: llama.cpp
+    model: sonnet
+    llama_cpp_instance: local
+    max_tokens: 4096
+    temperature: 0.7
+    active_status: in-development
+    done_on_success: true
+    source_types:
+      - plan-backend
+    timeout_minutes: 0
+    allowed_write_paths:
+      - internal
+      - cmd
+      - lifecycle/backend-plans
+      - lifecycle/architecture/decisions
+    git_identity:
+      name: Backend Developer Agent (llama.cpp)
+      email: backend-developer@kaos-control.local
+    prompt_templates:
+      backend-developer: |
+        You are a backend developer for the Innovation Maker project.
+        Read the backend plan at {target_path} and implement it milestone
+        by milestone in Go.
+
+        Scope of writes: internal/**, cmd/**, and — only for a proposed ADR —
+        lifecycle/architecture/decisions/. Do NOT modify web/, tests/, or other
+        lifecycle artifacts (other than blocking the input plan as described
+        below) — those belong to other agents.
+
+        Follow the architecture standards and ADRs in lifecycle/architecture/
+        (standards/ and decisions/). If the plan forces a deviation from the
+        recorded architecture or standards, do not deviate silently: propose a
+        new ADR in lifecycle/architecture/decisions/ (type: adr) capturing the
+        decision, context, and consequences; if you cannot, treat it as being
+        stuck (see below).
+
+        After each milestone:
+          - go build ./...
+          - go vet ./...
+        Both must pass before the milestone is considered complete.
+
+        Commit each milestone as its own git commit with a message that
+        references the plan's milestone heading.
+
+        ── If you get stuck ─────────────────────────────────────────────
+        If the plan is ambiguous, contradictory, or missing critical detail
+        you need to implement correctly, do NOT guess. Append a
+        `## Open Questions` section to the artifact at {target_path} listing
+        each blocking question explicitly. Update its frontmatter:
+          status: blocked
+          assignees:
+            - role: product-owner
+              who: agent
+        Then stop — do not commit partial code.
   - name: frontend-developer
     role:
       - frontend-developer


### PR DESCRIPTION
## Summary

Adds a new `llama.cpp` driver that lets you run local LLM inference via the llama.cpp HTTP API, complementary to the existing Ollama driver.

## Motivation

- Run local models without Ollama runtime dependency
- Compatible with llama.cpp server (`--port 8080`)
- Same driver interface as Ollama — streaming, prechecks, sandboxing all work

## Changes

### New files
- `internal/agent/llama_cpp.go` — Driver implementation using `/v1/chat/completions` endpoint

### Modified files
- `internal/config/config.go` — Added `LlamaCPPInstance` type, validation helper `validateInstances()`, agent params (`max_tokens`, `temperature`)
- `internal/agent/agent.go` — Added `LlamaCPPInstanceName`, `MaxTokens`, `Temperature` fields to `Run`

### Refactoring
- Extracted `validateInstances()` helper to dedupe validation logic for Ollama/llama.cpp instances

## Usage

### Global config (`~/.kaos-control/config.yaml`)

```yaml
llama_cpp_instances:
  - name: local
    base_url: http://localhost:8080
```

### Project config (`lifecycle/config.yaml`)

```yaml
agents:
  - name: coder
    roles: [backend-developer]
    driver: llama.cpp
    model: your-model.gguf
    llama_cpp_instance: local
    max_tokens: 4096
    temperature: 0.7
```

### Start llama.cpp server

```bash
llama.cpp/server -m models/your-model.gguf -c 4096 --port 8080 --cont-batching
```

## Testing

- Code compiles with `go build ./internal/agent/...`
- Config package typechecks successfully

## Notes

- Defaults `max_tokens: 4096`, `temperature: 0.7` if not set
- Falls through to default supervisor case (no precheck) like Ollama
- Instance name validation ensures uniqueness across both Ollama and llama.cpp instance lists